### PR TITLE
feat: Allow deleting all __bad__ with a single button

### DIFF
--- a/pkg/webdav/templates/directory.html
+++ b/pkg/webdav/templates/directory.html
@@ -106,6 +106,19 @@
     </li>
     {{- end}}
     {{$isBadPath := hasSuffix .Path "__bad__"}}
+    {{- if and $isBadPath (gt (len .Children) 0) }}
+    <li>
+        <span class="file-number">&nbsp;</span>
+        <span class="file-name">&nbsp;</span>
+        <span class="file-info">&nbsp;</span>
+        <button
+                class="delete-btn"
+                id="delete-all-btn"
+                data-name="{{.DeleteAllBadTorrentKey}}">
+            Delete All
+        </button>
+    </li>
+    {{- end}}
     {{- range $i, $file := .Children}}
     <li class="{{if $isBadPath}}disabled{{end}}">
         <a {{ if not $isBadPath}}href="{{urlpath (printf "%s/%s" $.Path $file.Name)}}"{{end}}>
@@ -118,7 +131,7 @@
         </a>
         {{- if and $.CanDelete }}
         <button
-                class="delete-btn"
+                class="delete-btn delete-with-id-btn"
                 data-name="{{$file.Name}}"
                 data-path="{{printf "%s/%s" $.Path $file.ID}}">
         Delete
@@ -128,7 +141,7 @@
     {{- end}}
 </ul>
 <script>
-    document.querySelectorAll('.delete-btn').forEach(btn=>{
+    document.querySelectorAll('.delete-with-id-btn').forEach(btn=>{
         btn.addEventListener('click', ()=>{
             let p = btn.getAttribute('data-path');
             let name = btn.getAttribute('data-name');
@@ -136,6 +149,14 @@
             fetch(p, { method: 'DELETE' })
                 .then(_=>location.reload());
         });
+    });
+
+    const deleteAllButton = document.getElementById('delete-all-btn');
+    deleteAllButton.addEventListener('click', () => {
+        let p = deleteAllButton.getAttribute('data-name');
+        if (!confirm('Delete all entries marked Bad?')) return;
+        fetch(p, { method: 'DELETE' })
+            .then(_=>location.reload());
     });
 </script>
 </body>


### PR DESCRIPTION
* introduces a constant value for the delete all key
* Adds conditional display of a "Delete All" button on the __bad__ directory listing page.
* renames handleIDDelete to handleDelete, and splits the logic to perform a delete by id if not delete all, else get the listings for the __bad__ dir, loop through the results if there are any, split the retrieved name from the cache to discard the size, and execute onRemove for the returned id of a t.