### PR TITLE
Retry with backoff when a torrent completes with zero files

### DIFF
--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -474,9 +474,89 @@ func (d *Downloader) processDownload(entry *storage.Entry) error {
 	return d.processTorrentDownload(entry)
 }
 
+// refreshFilesWithBackoff re-fetches the torrent from its active debrid
+// provider a few times with backoff when the entry has no files yet.
+//
+// Some debrid providers (Premiumize in particular) can flip a transfer's
+// status to "finished" before the underlying file's download link has
+// actually been generated on their side - most noticeably for content
+// that is already cached and completes in well under a second. The very
+// first status check right after submission can race this window and see
+// zero files, even though the same provider confirms a valid link for the
+// same file moments later. Without a retry, this permanently fails the
+// download with "no valid download links available" for torrents that,
+// paradoxically, were the fastest and most available to fetch.
+//
+// This gives the provider a short, bounded window (~30s across 5 attempts)
+// to catch up before giving up and returning the original empty result.
+func (d *Downloader) refreshFilesWithBackoff(entry *storage.Entry) []*storage.File {
+	provider := entry.GetActiveProvider()
+	if provider == nil {
+		return entry.GetActiveFiles()
+	}
+	client := d.manager.ProviderClient(provider.Provider)
+	if client == nil {
+		return entry.GetActiveFiles()
+	}
+
+	backoff := 2 * time.Second
+	const maxAttempts = 5
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		time.Sleep(backoff)
+		refreshed, err := client.GetTorrent(provider.ID)
+		if err != nil || refreshed == nil || len(refreshed.Files) == 0 {
+			if backoff < 16*time.Second {
+				backoff *= 2
+			}
+			continue
+		}
+		applyRefreshedFiles(entry, provider, refreshed)
+		if files := entry.GetActiveFiles(); len(files) > 0 {
+			d.logger.Info().Int("attempt", attempt+1).Str("name", entry.Name).
+				Msg("Recovered file links after provider was briefly not ready")
+			return files
+		}
+		if backoff < 16*time.Second {
+			backoff *= 2
+		}
+	}
+	return entry.GetActiveFiles()
+}
+
+// applyRefreshedFiles merges a freshly-fetched debrid torrent's files into
+// the entry: the canonical per-entry file list (name/size/path) and the
+// active provider's per-file link/id data used to resolve download links.
+func applyRefreshedFiles(entry *storage.Entry, provider *storage.ProviderEntry, refreshed *types.Torrent) {
+	if provider.Files == nil {
+		provider.Files = make(map[string]*storage.ProviderFile)
+	}
+	if entry.Files == nil {
+		entry.Files = make(map[string]*storage.File)
+	}
+	for name, f := range refreshed.Files {
+		provider.Files[name] = &storage.ProviderFile{
+			Id:   f.Id,
+			Link: f.Link,
+			Path: f.Path,
+		}
+		if _, exists := entry.Files[name]; !exists {
+			entry.Files[name] = &storage.File{
+				Name:     name,
+				Path:     f.Path,
+				Size:     f.Size,
+				InfoHash: entry.InfoHash,
+				AddedOn:  time.Now(),
+			}
+		}
+	}
+}
+
 // processTorrentDownload downloads files from debrid via HTTP
 func (d *Downloader) processTorrentDownload(entry *storage.Entry) error {
 	files := entry.GetActiveFiles()
+	if len(files) == 0 {
+		files = d.refreshFilesWithBackoff(entry)
+	}
 	d.logger.Info().Msgf("Downloading %d files...", len(files))
 
 	totalSize := int64(0)


### PR DESCRIPTION
## What

Adds a short, bounded retry (5 attempts, 2s/4s/8s/16s/16s backoff, ~30s total)
in `processTorrentDownload` that re-fetches the torrent from its active debrid
provider when `entry.GetActiveFiles()` comes back empty, before giving up with
"no valid download links available".

## Why

Some debrid providers (Premiumize in particular) can flip a transfer's status
to "finished" before the file's actual download link has been generated on
their side. This is most noticeable for content that's already cached and
completes in well under a second - the very first status check right after
submission can race that window and see zero files, even though the provider
confirms a valid link for the same file moments later.

Observed with Premiumize on already-cached single-file torrents (software
ISOs/installers). Example from my own logs:

```
16:35:19 | Processing torrent Action=download ... Name=debian-13.6.0-amd64-netinst.iso
16:35:21 | Entry: debian-13.6.0-amd64-netinst.iso submitted to Premiumize id=oqegB0k02IwNcfRmg_9jBA
16:35:22 | Download completed, processing action action=download name=debian-13.6.0-amd64-netinst.iso
16:35:22 | Downloading 0 files...
16:35:22 | ERROR Error running post-download action error="no valid download links available for debian-13.6.0-amd64-netinst.iso"
```

Submitted-to-failed in ~3 seconds. A manual `GET /api/item/details` against
Premiumize's API for the same file a few minutes later (for a different,
similarly-affected torrent) returned a fully populated `link`/`directlink`,
`virus_scan: "ok"`, correct size - i.e. genuinely ready, just not yet at the
moment `processTorrentDownload` looked.

Today this fails permanently and needs a manual re-add (which, for a torrent
already cached provider-side, just re-submits the same infohash and usually
works immediately, confirming it's a timing issue and not a bad source). The
existing repair worker can also catch this in the background if `source:
managed` is configured, but that's a several-minutes-later mitigation, not a
fix for the immediate failure on first grab from an *arr.

## Caveat

I don't have a Go toolchain available in the environment I wrote this in, so
**this has not been compiled or run**. I reviewed it by hand against the
current type definitions (`ProviderEntry`, `ProviderFile`, `storage.File`,
`debrid/types.Torrent`/`File`) and existing call sites for
`GetActiveProvider`/`ProviderClient`/`GetTorrent` elsewhere in the codebase,
but please build and test before merging - happy to fix up anything that
doesn't compile or behaves differently than intended.

Also open to a different shape entirely (e.g. hooking into the existing
repair/`RunChecks` machinery instead of a local retry loop) if that fits the
codebase's direction better - I went with the smallest, most self-contained
change I could reason about without a build.