### PR TITLE
fix(alldebrid): don't treat a ready magnet with no files yet as downloaded

### DIFF
--- a/pkg/debrid/providers/alldebrid/alldebrid.go
+++ b/pkg/debrid/providers/alldebrid/alldebrid.go
@@ -345,18 +345,36 @@ func (ad *AllDebrid) GetTorrent(torrentId string) (*types.Torrent, error) {
 	}
 	t.Bytes = data.Size
 	t.Seeders = data.Seeders
-	if status == "downloaded" {
-		t.Progress = 100
+	t.Status = ad.applyMagnetFiles(t, status, data)
+	return t, nil
+}
+
+// applyMagnetFiles fills in progress, speed and files from a magnet status
+// response. AllDebrid sometimes reports a magnet as ready (statusCode 4)
+// before the files list in that same /magnet/status response is actually
+// populated. Trusting that as a real completion used to leave decypharr with
+// a "downloaded" torrent that has zero files, so no symlink was ever created
+// for an otherwise finished download (see issues #113 and #122). When that
+// happens we report the torrent as still downloading instead, so the next
+// poll picks up the real file list.
+func (ad *AllDebrid) applyMagnetFiles(t *types.Torrent, status types.TorrentStatus, data magnetInfo) types.TorrentStatus {
+	if status == types.TorrentStatusDownloaded {
 		index := -1
 		files := ad.flattenFiles(t.Id, data.Files, "", &index)
-		t.Files = files
-	} else {
+		if len(files) == 0 && data.Size > 0 {
+			status = types.TorrentStatusDownloading
+		} else {
+			t.Progress = 100
+			t.Files = files
+		}
+	}
+	if status != types.TorrentStatusDownloaded {
 		if data.Size > 0 {
 			t.Progress = float64(data.Downloaded) / float64(data.Size) * 100
 		}
 		t.Speed = data.DownloadSpeed
 	}
-	return t, nil
+	return status
 }
 
 func (ad *AllDebrid) updateTorrent(t *types.Torrent) (int, error) {
@@ -378,7 +396,6 @@ func (ad *AllDebrid) updateTorrent(t *types.Torrent) (int, error) {
 	status := getAlldebridStatus(data.StatusCode)
 	name := data.Filename
 	t.Name = name
-	t.Status = status
 	t.Filename = name
 	t.OriginalFilename = name
 	t.Debrid = ad.config.Name
@@ -388,17 +405,7 @@ func (ad *AllDebrid) updateTorrent(t *types.Torrent) (int, error) {
 		t.InfoHash = data.Hash
 	}
 	t.Added = time.Unix(data.CompletionDate, 0)
-	if status == "downloaded" {
-		t.Progress = 100
-		index := -1
-		files := ad.flattenFiles(t.Id, data.Files, "", &index)
-		t.Files = files
-	} else {
-		if data.Size > 0 {
-			t.Progress = float64(data.Downloaded) / float64(data.Size) * 100
-		}
-		t.Speed = data.DownloadSpeed
-	}
+	t.Status = ad.applyMagnetFiles(t, status, data)
 	return data.StatusCode, nil
 }
 

--- a/pkg/debrid/providers/alldebrid/alldebrid_test.go
+++ b/pkg/debrid/providers/alldebrid/alldebrid_test.go
@@ -222,6 +222,83 @@ func TestCheckStatusDoesNotRestartTerminalStatus(t *testing.T) {
 	}
 }
 
+// AllDebrid can answer statusCode 4 (ready) with an empty files array in the
+// same response, before it has actually populated the file list. We used to
+// trust that as a real completion, so decypharr went ahead and created zero
+// symlinks for a torrent that was, from AllDebrid's own account page, fully
+// downloaded (issue #113, #122). GetTorrent should now report this as still
+// downloading instead of downloaded.
+func TestGetTorrentTreatsReadyWithNoFilesAsStillDownloading(t *testing.T) {
+	config.SetConfigPath(t.TempDir())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"status":"success","data":{"magnets":[{"id":1,"filename":"Release.mkv","statusCode":4,"size":1000,"downloaded":1000,"files":[]}]}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	ad := testAllDebrid(server.URL)
+	torrent, err := ad.GetTorrent("1")
+	if err != nil {
+		t.Fatalf("GetTorrent() error = %v", err)
+	}
+	if torrent.Status != debridTypes.TorrentStatusDownloading {
+		t.Fatalf("Status = %q, want %q for a ready magnet with no files yet", torrent.Status, debridTypes.TorrentStatusDownloading)
+	}
+	if len(torrent.Files) != 0 {
+		t.Fatalf("Files = %v, want none", torrent.Files)
+	}
+}
+
+// A magnet that is genuinely ready, with its files populated, should still
+// be reported as downloaded.
+func TestGetTorrentKeepsDownloadedWhenFilesArePresent(t *testing.T) {
+	config.SetConfigPath(t.TempDir())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"status":"success","data":{"magnets":[{"id":1,"filename":"Release.mkv","statusCode":4,"size":1000,"downloaded":1000,"files":[{"n":"Release.mkv","s":1000,"l":"https://alldebrid.com/f/xyz"}]}]}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	ad := testAllDebrid(server.URL)
+	torrent, err := ad.GetTorrent("1")
+	if err != nil {
+		t.Fatalf("GetTorrent() error = %v", err)
+	}
+	if torrent.Status != debridTypes.TorrentStatusDownloaded {
+		t.Fatalf("Status = %q, want %q", torrent.Status, debridTypes.TorrentStatusDownloaded)
+	}
+	if len(torrent.Files) != 1 {
+		t.Fatalf("Files = %v, want 1 file", torrent.Files)
+	}
+	if torrent.Progress != 100 {
+		t.Fatalf("Progress = %v, want 100", torrent.Progress)
+	}
+}
+
+// updateTorrent backs UpdateTorrent/CheckStatus, the path the active
+// downloader polls while a torrent is in progress, so it needs the same
+// guard as GetTorrent.
+func TestUpdateTorrentTreatsReadyWithNoFilesAsStillDownloading(t *testing.T) {
+	config.SetConfigPath(t.TempDir())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"status":"success","data":{"magnets":[{"id":1,"filename":"Release.mkv","statusCode":4,"size":1000,"downloaded":1000,"files":[]}]}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	ad := testAllDebrid(server.URL)
+	torrent := &debridTypes.Torrent{Id: "1"}
+	if err := ad.UpdateTorrent(torrent); err != nil {
+		t.Fatalf("UpdateTorrent() error = %v", err)
+	}
+	if torrent.Status != debridTypes.TorrentStatusDownloading {
+		t.Fatalf("Status = %q, want %q for a ready magnet with no files yet", torrent.Status, debridTypes.TorrentStatusDownloading)
+	}
+}
+
 func testAllDebrid(host string) *AllDebrid {
 	return &AllDebrid{
 		Host:               host,


### PR DESCRIPTION
## 📌 Description
- Fixes decypharr marking a torrent as downloaded with zero files when AllDebrid reports it ready before the files list is actually populated in that same response. This is the empty symlink folder people are hitting in #113 and #122.

---

## Target Branch Check (IMPORTANT)

- [x] I confirm this PR is targeting the correct branch

**Expected target:**

- [x] beta (for features)

---

## Changes Made

- Extracted the progress/files handling from GetTorrent and updateTorrent into a shared applyMagnetFiles helper
- When status is "downloaded" but the flattened files list is empty and the reported size is greater than zero, keep the torrent as downloading instead of downloaded
- Added tests covering both the empty files case and the normal case where files are present

---

## Testing

- [x] Tested locally

Steps:

1. Wrote a fake /magnet/status server returning statusCode 4 with an empty files array and a nonzero size, confirmed GetTorrent and UpdateTorrent both report the torrent as still downloading with this patch, and confirmed they reported it downloaded before the patch, which reproduces #113/#122
2. Ran the same test with files populated to make sure a genuinely finished torrent is not affected, still reported downloaded with progress at 100
3. Ran the full test suite (go test ./...) plus go vet and gofmt, all clean

---

## Risks / Notes

- Only touches AllDebrid's GetTorrent/updateTorrent, other providers aren't affected
- A torrent that genuinely has zero size and zero files still gets treated as downloaded like before, this only changes behavior when the reported size is greater than zero

---

## Screenshots (if applicable)

N/A

---

## Checklist

- [x] Code builds successfully
- [x] No console/log errors
- [x] Reviewed my own code
- [x] Target branch is correct
