### PR TITLE
fix(manager): populate files for completed queued downloads and add retry logic (mainly intended to fix an issue with AllDebrid)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ RUN apk add --no-cache fuse3 ca-certificates su-exec shadow curl unzip tzdata li
 COPY --from=builder /decypharr /usr/bin/decypharr
 COPY --from=builder /healthcheck /usr/bin/healthcheck
 COPY scripts/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
 
 # Set environment variables
 ENV PUID=1000

--- a/pkg/manager/downloader.go
+++ b/pkg/manager/downloader.go
@@ -41,6 +41,8 @@ const (
 	symlinkLogSampleSize        = 8
 	localDownloadMaxAttempts    = 4
 	defaultFileDownloadWorkers  = 5
+	symlinkFileCheckMaxRetries  = 6
+	symlinkFileCheckRetryDelay  = 10 * time.Second
 )
 
 type downloadLogMeta struct {
@@ -173,9 +175,53 @@ func (d *Downloader) markAsError(entry *storage.Entry, err error) {
 
 // processSymlink creates symlinks for torrent files
 func (d *Downloader) processSymlink(entry *storage.Entry, mountPath string) error {
-	files := entry.GetActiveFiles()
+	var files []*storage.File
+
+	for attempt := 1; attempt <= symlinkFileCheckMaxRetries; attempt++ {
+		files = entry.GetActiveFiles()
+
+		// If entry has no active files in memory, try to refresh from provider
+		if len(files) == 0 && d.manager != nil {
+			if placement := entry.GetActiveProvider(); placement != nil && entry.ActiveProvider != "" {
+				if client := d.manager.ProviderClient(entry.ActiveProvider); client != nil {
+					if t, err := client.GetTorrent(placement.ID); err == nil && t != nil && len(t.Files) > 0 {
+						applyDebridTorrentToEntry(entry, t)
+						if d.manager.queue != nil {
+							_ = d.manager.queue.Update(entry)
+						}
+						files = entry.GetActiveFiles()
+					}
+				}
+			}
+		}
+
+		// If still 0 files, check if files exist in the mount directory
+		if len(files) == 0 {
+			d.populateFilesFromMount(entry, mountPath)
+			files = entry.GetActiveFiles()
+		}
+
+		if len(files) > 0 {
+			break
+		}
+
+		if attempt < symlinkFileCheckMaxRetries {
+			d.logger.Warn().
+				Str("entry", entry.Name).
+				Str("mount_path", mountPath).
+				Int("attempt", attempt).
+				Int("max_attempts", symlinkFileCheckMaxRetries).
+				Msg("0 files found, waiting before retry...")
+			time.Sleep(symlinkFileCheckRetryDelay)
+		}
+	}
+
 	torrentSymlinkPath := entry.DownloadPath()
 	d.logger.Info().Str("mount_path", mountPath).Msgf("Creating symlinks for %d files in %s", len(files), torrentSymlinkPath)
+
+	if len(files) == 0 {
+		return fmt.Errorf("failed to create symlinks: 0 files found for %s in %s after %d attempts", entry.Name, mountPath, symlinkFileCheckMaxRetries)
+	}
 
 	// Create symlink directory
 	err := os.MkdirAll(torrentSymlinkPath, os.ModePerm)
@@ -189,7 +235,9 @@ func (d *Downloader) processSymlink(entry *storage.Entry, mountPath string) erro
 	}
 
 	entry.IsDownloading = true
-	_ = d.manager.queue.Update(entry)
+	if d.manager != nil && d.manager.queue != nil {
+		_ = d.manager.queue.Update(entry)
+	}
 
 	if err := d.waitForSymlinkFilesReady(filePaths, symlinkReadyTimeout); err != nil {
 		return err
@@ -215,6 +263,49 @@ func (d *Downloader) processSymlink(entry *storage.Entry, mountPath string) erro
 	d.completeEntry(entry)
 
 	return nil
+}
+
+func (d *Downloader) populateFilesFromMount(entry *storage.Entry, mountPath string) {
+	entries, err := os.ReadDir(mountPath)
+	if err != nil {
+		return
+	}
+
+	var scanDir func(string)
+	scanDir = func(dirPath string) {
+		items, err := os.ReadDir(dirPath)
+		if err != nil {
+			return
+		}
+		for _, item := range items {
+			entryName := item.Name()
+			fullPath := filepath.Join(dirPath, entryName)
+			if item.IsDir() {
+				scanDir(fullPath)
+				continue
+			}
+			if entry.Files == nil {
+				entry.Files = make(map[string]*storage.File)
+			}
+			if _, exists := entry.Files[entryName]; !exists {
+				info, err := item.Info()
+				var size int64
+				if err == nil {
+					size = info.Size()
+				}
+				entry.Files[entryName] = &storage.File{
+					Name:     entryName,
+					Size:     size,
+					InfoHash: entry.InfoHash,
+					AddedOn:  entry.AddedOn,
+				}
+			}
+		}
+	}
+
+	if len(entries) > 0 {
+		scanDir(mountPath)
+	}
 }
 
 func (d *Downloader) createSymlinksWhenMountFilesAppear(entry *storage.Entry, files []*storage.File, mountPath string, symlinkDir string) ([]string, error) {

--- a/pkg/manager/processor.go
+++ b/pkg/manager/processor.go
@@ -304,6 +304,7 @@ func (m *Manager) processQueuedTorrent(entry *storage.Entry) {
 	}
 
 	// Update entry progress
+	applyDebridTorrentToEntry(entry, debridTorrent)
 	entry.Progress = debridTorrent.Progress / 100.0
 	entry.Speed = debridTorrent.Speed
 	entry.Size = debridTorrent.GetSize()


### PR DESCRIPTION
## 📌 Description

When uncached torrents finish downloading via a debrid provider (e.g. AllDebrid), processQueuedTorrent detected status TorrentStatusDownloaded but did not call applyDebridTorrentToEntry(entry, debridTorrent).

Because of this omission:

entry.Files remained empty in memory.
processSymlink() received 0 active files, logging Creating symlinks for 0 files... and creating no symlinks (causing Arr import failures).
This PR fixes the issue by:

Calling applyDebridTorrentToEntry(entry, debridTorrent) in processQueuedTorrent() so files returned by debrid status checks are synced to the entry.
Adding a retry safety net in processSymlink() (up to 6 attempts, 10s backoff) that attempts provider/directory re-checks before failing.


## Target Branch Check (IMPORTANT)

- [x] I confirm this PR is targeting the correct branch

**Expected target:**

- [x] beta (for features)

---

## Changes Made

- **`pkg/manager/processor.go`**: Called `applyDebridTorrentToEntry(entry, debridTorrent)` in `processQueuedTorrent()`. When a queued download completes, files and provider metadata are now correctly synced to `entry.Files`.
- **`pkg/manager/downloader.go`**: Added a retry loop in `processSymlink()` (up to 6 attempts with 10s backoff) that attempts provider refresh and mount scanning (`populateFilesFromMount`) before failing with 0 files.
- **`Dockerfile`**: Added `sed` to strip potential CRLF carriage returns from `/entrypoint.sh` during image build.

---

## Testing

- [x] Tested locally

Steps:

1. Built container image using Docker Compose on Linux host.
2. Submitted an uncached season pack via Sonarr with AllDebrid provider.
3. Monitored logs while the torrent finished downloading in the queue: verified `applyDebridTorrentToEntry` properly populated all files and symlinks were created successfully (`Creating symlinks for 10 files...`), allowing Sonarr to import the release immediately.

---

## Risks / Notes

- None identified. Should be safe and backward-compatible fix.

---

## Screenshots (if applicable)

*N/A*
---

## Checklist

- [x] Code builds successfully
- [x] No console/log errors
- [x] Reviewed my own code
- [x] Target branch is correct