### PR TITLE
fix(link): skip validation for links that are already expired

### DIFF
--- a/pkg/debrid/account/account.go
+++ b/pkg/debrid/account/account.go
@@ -49,6 +49,13 @@ func (a *Account) sliceFileLink(fileLink string) string {
 func (a *Account) GetDownloadLink(id string, file *types.File, fetcher LinkFetcher) (types.DownloadLink, error) {
 	slicedLink := a.sliceFileLink(file.Link)
 	dl, ok := a.links.Load(slicedLink)
+	if ok && dl.Expired() {
+		// The cache is keyed by file link, not by lifetime, so an entry can
+		// outlive the download URL it holds. Serving it only buys a doomed
+		// request downstream, so drop it and fetch a fresh one.
+		a.links.Delete(slicedLink)
+		ok = false
+	}
 	if !ok {
 		var err error
 		dl, err = fetcher(a, id, file)

--- a/pkg/debrid/account/account_test.go
+++ b/pkg/debrid/account/account_test.go
@@ -1,0 +1,133 @@
+package account
+
+import (
+	"testing"
+	"time"
+
+	"github.com/puzpuzpuz/xsync/v4"
+	"github.com/sirrobot01/decypharr/pkg/debrid/types"
+)
+
+func newTestAccount(debrid string) *Account {
+	return &Account{
+		Debrid: debrid,
+		Token:  "test-token",
+		links:  xsync.NewMap[string, types.DownloadLink](),
+	}
+}
+
+func countingFetcher(url string, expiresAt time.Time, calls *int) LinkFetcher {
+	return func(_ *Account, _ string, file *types.File) (types.DownloadLink, error) {
+		*calls++
+		return types.DownloadLink{
+			Filename:     file.Name,
+			Link:         file.Link,
+			DownloadLink: url,
+			Debrid:       "torbox",
+			Generated:    time.Now(),
+			ExpiresAt:    expiresAt,
+		}, nil
+	}
+}
+
+func TestGetDownloadLinkServesCachedLinkThatIsStillValid(t *testing.T) {
+	acc := newTestAccount("torbox")
+	file := &types.File{Name: "file.mkv", Link: "torbox://1/0"}
+
+	acc.storeLink(types.DownloadLink{
+		Link:         file.Link,
+		DownloadLink: "https://cdn.example.com/cached",
+		Debrid:       "torbox",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	})
+
+	calls := 0
+	dl, err := acc.GetDownloadLink("1", file, countingFetcher("https://cdn.example.com/fresh", time.Now().Add(time.Hour), &calls))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected the cached link to be served without a fetch, got %d fetches", calls)
+	}
+	if dl.DownloadLink != "https://cdn.example.com/cached" {
+		t.Fatalf("expected the cached link, got %q", dl.DownloadLink)
+	}
+}
+
+func TestGetDownloadLinkEvictsExpiredCachedLink(t *testing.T) {
+	acc := newTestAccount("torbox")
+	file := &types.File{Name: "file.mkv", Link: "torbox://1/0"}
+
+	acc.storeLink(types.DownloadLink{
+		Link:         file.Link,
+		DownloadLink: "https://cdn.example.com/expired",
+		Debrid:       "torbox",
+		Generated:    time.Now().Add(-2 * time.Hour),
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	})
+
+	calls := 0
+	dl, err := acc.GetDownloadLink("1", file, countingFetcher("https://cdn.example.com/fresh", time.Now().Add(time.Hour), &calls))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly one fetch after eviction, got %d", calls)
+	}
+	if dl.DownloadLink != "https://cdn.example.com/fresh" {
+		t.Fatalf("expected the refetched link, got %q", dl.DownloadLink)
+	}
+
+	cached, ok := acc.links.Load(acc.sliceFileLink(file.Link))
+	if !ok {
+		t.Fatal("expected the fresh link to be cached")
+	}
+	if cached.DownloadLink != "https://cdn.example.com/fresh" {
+		t.Fatalf("expected the cache to hold the fresh link, got %q", cached.DownloadLink)
+	}
+}
+
+// Providers that don't expose an expiry leave ExpiresAt zero; those entries must
+// keep their previous never-evicted behaviour.
+func TestGetDownloadLinkKeepsCachedLinkWithoutExpiry(t *testing.T) {
+	acc := newTestAccount("torbox")
+	file := &types.File{Name: "file.mkv", Link: "torbox://1/0"}
+
+	acc.storeLink(types.DownloadLink{
+		Link:         file.Link,
+		DownloadLink: "https://cdn.example.com/no-expiry",
+		Debrid:       "torbox",
+		Generated:    time.Now().Add(-72 * time.Hour),
+	})
+
+	calls := 0
+	dl, err := acc.GetDownloadLink("1", file, countingFetcher("https://cdn.example.com/fresh", time.Time{}, &calls))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected no fetch for a link without an expiry, got %d", calls)
+	}
+	if dl.DownloadLink != "https://cdn.example.com/no-expiry" {
+		t.Fatalf("expected the cached link, got %q", dl.DownloadLink)
+	}
+}
+
+func TestDownloadLinkExpired(t *testing.T) {
+	cases := map[string]struct {
+		expiresAt time.Time
+		want      bool
+	}{
+		"zero expiry is never expired": {time.Time{}, false},
+		"future expiry":                {time.Now().Add(time.Hour), false},
+		"past expiry":                  {time.Now().Add(-time.Hour), true},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			dl := types.DownloadLink{DownloadLink: "https://cdn.example.com/x", ExpiresAt: tc.expiresAt}
+			if got := dl.Expired(); got != tc.want {
+				t.Fatalf("Expired() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/debrid/types/torrent.go
+++ b/pkg/debrid/types/torrent.go
@@ -172,6 +172,13 @@ func (dl *DownloadLink) Valid() error {
 	return nil
 }
 
+// Expired reports whether the link is past the expiry the provider (or
+// auto_expire_links_after) gave it. Providers that don't expose an expiry leave
+// ExpiresAt zero; those links are never considered expired.
+func (dl *DownloadLink) Expired() bool {
+	return !dl.ExpiresAt.IsZero() && time.Now().After(dl.ExpiresAt)
+}
+
 func (dl *DownloadLink) Empty() bool {
 	return dl.DownloadLink == ""
 }

--- a/pkg/manager/link/service.go
+++ b/pkg/manager/link/service.go
@@ -123,6 +123,18 @@ func (s *Service) fetchAndValidate(ctx context.Context, entry *storage.Entry, fi
 		return s.handleBadLink(ctx, err, entry, link, attempt)
 	}
 
+	// A link we already know is expired cannot be validated back to life: the
+	// HEAD below would burn the whole retry ladder before landing in
+	// invalidateAndRefetch anyway. Refetch first, then validate the fresh link
+	// once through the normal path.
+	if link.Expired() && link.Debrid != "" {
+		fresh, refetchErr := s.invalidateAndRefetch(ctx, entry, link, attempt)
+		if refetchErr != nil {
+			return fresh, refetchErr
+		}
+		link = fresh
+	}
+
 	// Is link already validated
 	// Check if we've already validated this link
 	if validationErr, exists := s.validated.Load(link.DownloadLink); exists {


### PR DESCRIPTION
## Problem

Download links are cached in two places and neither cache looks at
`DownloadLink.ExpiresAt`:

1. `pkg/debrid/account/account.go` — `Account.GetDownloadLink` returns whatever is
   stored under the sliced file link. The only check on the way out is `Valid()`,
   which just verifies the URL parses. A cached entry therefore outlives the
   download URL it holds, indefinitely, until the process restarts or something
   else deletes it.
2. `pkg/manager/link/service.go` — `fetchAndValidate` takes the link from
   `fetchLink` and validates it (HEAD) without ever considering its age. Only
   after validation fails in a retryable way does `invalidateAndRefetch` (#384)
   drop the link and request a fresh one.

So a link the code already knows is expired still goes through the full
validation retry ladder — ~60 s with default retry/backoff settings — before it
is refetched. During streaming the reader blocks for that whole minute, once per
file: on playback start when the mount's cache doesn't already hold the head of
the file, and on seeks past the cached region.

## Reproduction

Provider whose CDN rejects an expired download token (TorBox returns a bodyless
`400` for an unknown/expired download UUID; a bad token gives `401`, so this is
specifically "this UUID is gone"):

1. Fetch a download link for a file — it lands in the account cache and in
   `linkService.validated`.
2. Wait past its `ExpiresAt` (default `auto_expire_links_after` is 3d; the
   midnight `linkService.Clear()` job also drops the `validated` entry, so the
   next read takes the un-memoized path).
3. Read the file.

Observed: `fetchLink` returns the stale URL from the account cache, `validateLink`
HEADs it, the CDN answers 400, the retry ladder runs to exhaustion (~60 s), and
only then is a fresh link fetched. The refetched link works, which confirms
nothing was wrong except the age of the cached one.

## Fix

- `types.DownloadLink.Expired()` — `ExpiresAt` in the past, and non-zero. A zero
  `ExpiresAt` means the provider didn't tell us a lifetime, and those links keep
  their current behaviour exactly.
- `Account.GetDownloadLink` evicts an expired entry on read and falls through to
  the fetcher, instead of handing back a URL it knows is dead.
- `fetchAndValidate` checks expiry immediately after `fetchLink` and, when the
  link is expired, goes straight to `invalidateAndRefetch`; the fresh link then
  continues through the normal path and is validated once. No extra HEAD, no
  ladder, no recursion.

Every provider that sets `ExpiresAt` derives it from `auto_expire_links_after`
(alldebrid, debridlink, premiumize, realdebrid, torbox), each falling back to 48h
when the config value is empty or unparseable, so `ExpiresAt` is never
accidentally zero-valued-into-the-past. Code paths that build a `DownloadLink`
without an expiry are unaffected.

## Deliberately not included

`pkg/manager/workers.go` schedules `linkService.Clear()` at 00:00 CET and clears
only the validation memo — `Account.ClearDownloadLinks()` exists and is unused,
which is the other half of why a stale link could survive the night. Adding the
account clear to that job would work, but with expiry enforced on read it mostly
discards links that are still perfectly good, and it needs the manager to reach
into every provider's account manager. Happy to add it (or to drop the scheduled
clear entirely, which the read-side check makes redundant) if you'd prefer that
in the same PR.

## Tests

New `pkg/debrid/account/account_test.go` (the package had no tests):

- a cached entry whose `ExpiresAt` is in the future is served without calling the
  fetcher;
- an entry past `ExpiresAt` is evicted, the fetcher is called exactly once, and
  the fresh link replaces it in the cache;
- an entry with a zero `ExpiresAt` is still served from cache regardless of age
  (the no-op guarantee for providers that don't expose a lifetime);
- table test for `Expired()` itself.

`go build ./...`, `go vet ./...` clean. `go test ./...` passes except for two
pre-existing failures unrelated to this change (`pkg/storage`
`TestDowngradeRoundTripsThroughVersion3` and the two `pkg/share` tests), which
fail identically on an unmodified checkout of `main` on this machine.
